### PR TITLE
this should make proxy server run a central main

### DIFF
--- a/ProxyServer.py
+++ b/ProxyServer.py
@@ -1,31 +1,15 @@
 #!/usr/bin/python
 """Main proxy process."""
-from __future__ import print_function
-from json import dumps
 import cherrypy
+from proxy import error_page_default, main
+from proxy.globals import CHERRYPY_CONFIG
 from proxy.root import Root
-
-
-def error_page_default(**kwargs):
-    """The default error page should always enforce json."""
-    cherrypy.response.headers['Content-Type'] = 'application/json'
-    return dumps({
-        'status': kwargs['status'],
-        'message': kwargs['message'],
-        'traceback': kwargs['traceback'],
-        'version': kwargs['version']
-    })
-
-
-def main():
-    """Main method for running the server."""
-    cherrypy.quickstart(Root(), '/', 'server.conf')
 
 
 cherrypy.config.update({'error_page.default': error_page_default})
 # pylint doesn't realize that application is actually a callable
 # pylint: disable=invalid-name
-application = cherrypy.Application(Root(), '/', 'server.conf')
+application = cherrypy.Application(Root(), '/', CHERRYPY_CONFIG)
 # pylint: enable=invalid-name
 if __name__ == '__main__':
     main()

--- a/proxy/files.py
+++ b/proxy/files.py
@@ -3,7 +3,7 @@
 from json import loads
 import requests
 import cherrypy
-from proxy import METADATA_ENDPOINT, NGINX_X_ACCEL, ARCHIVEI_ENDPOINT
+from proxy.globals import METADATA_ENDPOINT, NGINX_X_ACCEL, ARCHIVEI_ENDPOINT
 
 
 # pylint: disable=too-few-public-methods

--- a/proxy/globals.py
+++ b/proxy/globals.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+"""Global static configuration."""
+from os import getenv
+
+
+CHERRYPY_CONFIG = getenv('CHERRYPY_CONFIG', 'server.conf')
+DEFAULT_ARCHIVEI_ENDPOINT = getenv('ARCHIVEI_PORT', 'tcp://127.0.0.1:8080').replace('tcp', 'http')
+ARCHIVEI_ENDPOINT = getenv('ARCHIVEI_ENDPOINT', DEFAULT_ARCHIVEI_ENDPOINT)
+DEFAULT_METADATA_ENDPOINT = getenv('METADATA_PORT', 'tcp://127.0.0.1:8121').replace('tcp', 'http')
+METADATA_ENDPOINT = getenv('METADATA_ENDPOINT', DEFAULT_METADATA_ENDPOINT)
+METADATA_CONNECT_ATTEMPTS = 40
+METADATA_WAIT = 3
+METADATA_STATUS_URL = '{0}/groups'.format(METADATA_ENDPOINT)
+
+DEFAULT_NGINX_X_ACCEL = getenv('NGINX_ACCEL', 'False')
+NGINX_X_ACCEL = DEFAULT_NGINX_X_ACCEL == 'True'

--- a/proxy/test/test_files.py
+++ b/proxy/test/test_files.py
@@ -4,7 +4,7 @@ import sys
 from json import loads
 import requests
 from cherrypy.test import helper
-import proxy
+from proxy.globals import METADATA_ENDPOINT
 from proxy.test.test_common import CommonCPSetup
 
 
@@ -20,7 +20,7 @@ class TestFilesObject(helper.CPWebCase, CommonCPSetup):
         """Test for a file."""
         files = loads(
             requests.get(
-                '{0}/files?_id=104'.format(proxy.METADATA_ENDPOINT)
+                '{0}/files?_id=104'.format(METADATA_ENDPOINT)
             ).text
         )
         self.assertTrue(len(files) > 0)
@@ -42,7 +42,7 @@ class TestFilesObject(helper.CPWebCase, CommonCPSetup):
         sys.modules['proxy.files'].NGINX_X_ACCEL = True
         files = loads(
             requests.get(
-                '{0}/files?_id=104'.format(proxy.METADATA_ENDPOINT)
+                '{0}/files?_id=104'.format(METADATA_ENDPOINT)
             ).text
         )
         self.assertTrue(len(files) > 0)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='PacificaProxy',
       description='Pacifica Proxy',
       author='David Brown',
       author_email='david.brown@pnnl.gov',
-      packages=['proxy', 'proxy.text'],
+      packages=['proxy', 'proxy.test'],
       entry_point={
           'console_scripts': ['ProxyServer=proxy:main'],
       },

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(name='PacificaProxy',
       description='Pacifica Proxy',
       author='David Brown',
       author_email='david.brown@pnnl.gov',
-      packages=['proxy'],
+      packages=['proxy', 'proxy.text'],
+      entry_point={
+          'console_scripts': ['ProxyServer=proxy:main'],
+      },
       scripts=['ProxyServer.py'],
       install_requires=[str(ir.req) for ir in INSTALL_REQS])

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -5,7 +5,7 @@ export POSTGRES_ENV_POSTGRES_PASSWORD=
 pushd travis
 MetadataServer.py &
 MD_PID=$!
-archiveinterfaceserver.py &
+ArchiveInterfaceServer.py &
 AI_PID=$!
 popd
 MAX_TRIES=60

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -29,6 +29,11 @@ echo '{ "hashsum": "'$readme_sha1'", "hashtype": "sha1", "size": '$readme_size'}
 
 export PYTHONPATH=$PWD
 coverage run --include='proxy/*' -m pytest -v
+coverage run --include='proxy/*' -a ProxyServer.py &
+SERVER_PID=$!
+sleep 2
+kill $SERVER_PID
+
 coverage report -m --fail-under=100
 if [[ $CODECLIMATE_REPO_TOKEN ]] ; then
   codeclimate-test-reporter


### PR DESCRIPTION
### Description

This adds an entrypoint to setup.py and makes the cherrypy config global env
### Issues Resolved

N/A
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
