### PR TITLE
Fix #16 add status url

### DIFF
--- a/pacifica/proxy/rest.py
+++ b/pacifica/proxy/rest.py
@@ -26,9 +26,17 @@ class Root(object):
     not exposed by default the base objects are exposed
     """
 
-    exposed = False
+    exposed = True
 
     def __init__(self):
         """Create the local objects we need."""
         self.files = Files()
+
+    @staticmethod
+    @cherrypy.tools.json_out()
+    # pylint: disable=invalid-name
+    def GET():
+        """Return happy message about functioning service."""
+        return {'message': 'Pacifica Proxy Up and Running'}
+    # pylint: enable=invalid-name
 # pylint: enable=too-few-public-methods

--- a/tests/root_test.py
+++ b/tests/root_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Test the main method."""
+from json import loads
 from cherrypy.test import helper
 from pacifica.proxy.rest import Root
 from common_test import CommonCPSetup
@@ -17,3 +18,11 @@ class TestRootObject(helper.CPWebCase, CommonCPSetup):
         """Test the root object."""
         root = Root()
         self.assertFalse(root is None)
+
+    def test_status_url(self):
+        """Test the status url on root."""
+        self.getPage('/')
+        self.assertStatus('200 OK')
+        data = loads(self.body)
+        self.assertTrue('message' in data, 'Body of status has message key')
+        self.assertEqual(data['message'], 'Pacifica Proxy Up and Running', 'content of message is specific')


### PR DESCRIPTION
### Description

This adds a basic status url for verifying the service is up and
running.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #16
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
